### PR TITLE
remove version from mlugg/setup-zig

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: mlugg/setup-zig@v1
-        with:
-          version: 0.14.0
       - run: |
           zig build ci --summary all
       - if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64' }}


### PR DESCRIPTION
The zig version used by setup-zig should now be pulled from the minimum_zig_version in the build.zig.zon file, same as what anyzig does.