### PR TITLE
Feature/show available releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .zig-cache/
 zig-out/
+notes.txt

--- a/src/main.zig
+++ b/src/main.zig
@@ -586,14 +586,6 @@ const DownloadUrl = struct {
     }
 };
 
-const ShowReleasesError = error{
-    DownloadFailed,
-    FileOpenFailed,
-    FileReadFailed,
-    JsonParseFailed,
-    OutOfMemory,
-};
-
 fn showAvailableReleases(arena: Allocator) !void {
     const app_data_path = try std.fs.getAppDataDir(arena, "anyzig");
     defer arena.free(app_data_path);

--- a/src/main.zig
+++ b/src/main.zig
@@ -262,13 +262,19 @@ pub fn main() !void {
                 );
                 std.process.exit(0xff);
             }
+            if (std.mem.eql(u8, command, "available")) {
+                std.log.info("Finding available releases...", .{});
+                try showAvailableReleases(arena);
+                std.process.exit(0);
+            }
         }
         if (manual_version) |version| break :blk .{ version, false };
         const build_root = try findBuildRoot(arena, build_root_options) orelse {
             try std.io.getStdErr().writeAll(
                 "no build.zig to pull a zig version from, you can:\n" ++
                     "  1. run '" ++ exe_str ++ " VERSION' to specify a version\n" ++
-                    "  2. run from a directory where a build.zig can be found\n",
+                    "  2. run '" ++ exe_str ++ " AVAILABLE' to see all available downloads\n" ++
+                    "  3. run from a directory where a build.zig can be found\n",
             );
             std.process.exit(0xff);
         };
@@ -580,6 +586,53 @@ const DownloadUrl = struct {
         }
     }
 };
+
+fn showAvailableReleases(arena: Allocator) !void {
+    const app_data_path = try std.fs.getAppDataDir(arena, "anyzig");
+    defer arena.free(app_data_path);
+
+    const download_index_kind: DownloadIndexKind = .official;
+    const index_path = try std.fs.path.join(arena, &.{ app_data_path, download_index_kind.basename() });
+    defer arena.free(index_path);
+
+    try downloadFile(arena, download_index_kind.url(), index_path);
+
+    // Read the index file
+    const file = try std.fs.cwd().openFile(index_path, .{});
+    defer file.close();
+    const index_content = try file.readToEndAlloc(arena, std.math.maxInt(usize));
+    defer arena.free(index_content);
+
+    // Parse the JSON
+    const root = try std.json.parseFromSlice(std.json.Value, arena, index_content, .{
+        .allocate = .alloc_if_needed,
+    });
+    defer root.deinit();
+
+    // Get all version objects
+    const versions = root.value.object;
+
+    // First show master version if available
+    if (versions.get("master")) |master_obj| {
+        if (master_obj.object.get("version")) |version_val| {
+            std.log.info("master ({s})", .{version_val.string});
+        }
+    }
+
+    // Then show all other versions
+    var it = versions.iterator();
+    while (it.next()) |entry| {
+        const version_str = entry.key_ptr.*;
+        if (std.mem.eql(u8, version_str, "master")) continue;
+
+        const version_obj = entry.value_ptr.*.object;
+        if (version_obj.get(json_arch_os)) |arch_os_obj| {
+            if (arch_os_obj.object.get("tarball")) |_| {
+                std.log.info("{s}", .{version_str});
+            }
+        }
+    }
+}
 
 fn makeOfficialUrl(arena: Allocator, semantic_version: SemanticVersion) DownloadUrl {
     return switch (determineVersionKind(semantic_version)) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -263,7 +263,6 @@ pub fn main() !void {
                 std.process.exit(0xff);
             }
             if (std.mem.eql(u8, command, "available")) {
-                std.log.info("Finding available releases...", .{});
                 try showAvailableReleases(arena);
                 std.process.exit(0);
             }
@@ -603,6 +602,8 @@ fn showAvailableReleases(arena: Allocator) !void {
     const index_path = try std.fs.path.join(arena, &.{ app_data_path, download_index_kind.basename() });
     defer arena.free(index_path);
 
+    log.info("Finding available releases...", .{});
+
     downloadFile(arena, download_index_kind.url(), index_path) catch |err| {
         log.err("Failed to download release index: {s}", .{@errorName(err)});
         return error.DownloadFailed;
@@ -634,8 +635,10 @@ fn showAvailableReleases(arena: Allocator) !void {
         return;
     }
 
-    std.log.info("Available Zig releases for {s}-{s}:", .{ os, arch });
-    std.log.info("----------------------------------------", .{});
+    // using this avoids the "anyzig: " prefix for formatting
+    io.getStdOut().writer().print("\n", .{}) catch {};
+    log.info("Available Zig releases for {s}-{s}:", .{ os, arch });
+    log.info("----------------------------------------", .{});
 
     if (versions.get("master")) |master_obj| {
         if (master_obj.object.get("version")) |version_val| {


### PR DESCRIPTION
## Description
Added a command to show available Zig releases for the current platform

## Changes
- Added `showAvailableReleases` function to display compatible versions
- Added handling for "available" flag in main

## Testing
- Functional on Windows and Arch (both x86)

## Notes
- The feature shows current master version as well
- Only shows versions available for the current platform
- Integrates already existing `downloadFile` function
- Checks versions against hashstore and shows which are installed