### PR TITLE
Exit more gracefully on download

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -363,6 +363,12 @@ pub fn main() !void {
     const versioned_exe = try global_cache_directory.joinZ(arena, &.{ hash.path(), exe_str });
     defer arena.free(versioned_exe);
 
+    // If we just downloaded the version and there are no additional arguments,
+    // assume user wanted to do this and exit more gracefully
+    if (maybe_hash == null and argv_index >= all_args.len) {
+        std.process.exit(0);
+    }
+
     const stay_alive = is_init or (builtin.os.tag == .windows);
 
     if (stay_alive) {


### PR DESCRIPTION
When a user tries to download a version using semantics like this: 'zig 0.14.0', it downloads the release and then attempts to run the release without any arguments. This change assumes that the user intended to do this and exits rather than returns Zigs "no commands" error.

Notes:
- This change only applies to downloading, running 'zig 0.14.0' will still return Zigs "no commands" error if the release is already installed.