### PR TITLE
Refactored the source code to use a unifed reporting module

### DIFF
--- a/src/LockFile.zig
+++ b/src/LockFile.zig
@@ -3,6 +3,7 @@ pub const LockFile = @This();
 
 const builtin = @import("builtin");
 const std = @import("std");
+const Reporting = @import("reporting.zig");
 
 path: []const u8,
 file: std.fs.File,
@@ -25,7 +26,7 @@ pub fn lock(path: []const u8) !LockFile {
         .windows => std.os.windows.GetCurrentProcessId(),
         .linux => std.os.linux.getpid(),
         .macos => std.c.getpid(),
-        else => @compileError("todo"),
+        else => Reporting.throwError("LockFile: unsupported OS", .{}),
     };
     var pid_buffer: [40]u8 = undefined;
     const pid_text = try std.fmt.bufPrint(&pid_buffer, "{d}", .{pid});
@@ -43,6 +44,6 @@ pub fn unlock(self: *LockFile) void {
     self.file.close();
     std.fs.cwd().deleteFile(self.path) catch |err| switch (err) {
         error.FileNotFound => {},
-        else => |e| std.debug.panic("failed to delete lock file '{s}' with {s}", .{ self.path, @errorName(e) }),
+        else => |e| Reporting.panic("failed to delete lock file '{s}' with {s}", .{ self.path, @errorName(e) }),
     };
 }

--- a/src/hashstore.zig
+++ b/src/hashstore.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zig = @import("zig");
 const LockFile = @import("LockFile.zig");
-const anyzig = @import("root");
+const Reporting = @import("reporting.zig");
 
 pub fn init(path: []const u8) !void {
     std.fs.cwd().makePath(path) catch |err| switch (err) {
@@ -51,7 +51,7 @@ pub fn find(hashstore_path: []const u8, name: []const u8) !?zig.Package.Hash {
     defer arena.free(full_content);
     const hash_bytes = std.mem.trim(u8, full_content, &std.ascii.whitespace);
     if (hash_bytes.len > zig.Package.Hash.max_len) {
-        anyzig.log.warn(
+        Reporting.criticalWarn(
             "{s}: file is too big (max is {})",
             .{ lock.hashfile_path, zig.Package.Hash.max_len },
         );

--- a/src/reporting.zig
+++ b/src/reporting.zig
@@ -1,0 +1,90 @@
+const std = @import("std");
+
+// the logging done in this struct is printed conditionally based on the verbosity level
+pub const Reporter = struct {
+    // this might be more useful to have as an enum of levels rather than bools like this
+    verbose_enabled: bool = false,
+    debug_enabled: bool = false,
+
+    pub fn init(verbose_enabled: bool, debug_enabled: bool) Reporter {
+        return .{
+            .verbose_enabled = verbose_enabled,
+            .debug_enabled = debug_enabled,
+        };
+    }
+
+    pub fn info(self: *const Reporter, comptime format: []const u8, args: anytype) void {
+        if (self.verbose_enabled) {
+            logWithPrefix("anyzig.info: ", format, args, "info message");
+        }
+    }
+
+    pub fn debug(self: *const Reporter, comptime format: []const u8, args: anytype) void {
+        if (self.debug_enabled) {
+            logWithPrefix("anyzig.debug: ", format, args, "debug message");
+        }
+    }
+
+    pub fn warn(self: *const Reporter, comptime format: []const u8, args: anytype) void {
+        if (self.verbose_enabled or self.debug_enabled) {
+            logWithPrefix("anyzig.warn: ", format, args, "warn message");
+        }
+    }
+};
+
+// the most basic logging function, no prefix
+//useful for printing menus and formatting
+pub fn log(comptime format: []const u8, args: anytype) void {
+    logWithPrefix("", format, args, "log");
+}
+
+// throw error will exit the program with a default exit code
+// it might be useful to make an error module to hold enums for error sets and codes
+pub fn throwError(comptime format: []const u8, args: anytype) void {
+    throwErrorWithExitCode(format, args, 0xff);
+}
+
+pub fn throwErrorWithExitCode(comptime format: []const u8, args: anytype, exit_code: u8) void {
+    logWithPrefix("anyzig.error: ", format, args, "error message");
+    std.process.exit(exit_code);
+}
+
+// panic uses zig's standard panic function
+pub fn panic(comptime format: []const u8, args: anytype) void {
+    std.debug.panic("anyzig.panic: " ++ format ++ "\n", args);
+}
+
+// used when a warning should be shown regardless of verbosity
+pub fn criticalWarn(comptime format: []const u8, args: anytype) void {
+    logWithPrefix("anyzig.critical: ", format, args, "critical warn message");
+}
+
+// Writer methods below, internal use only
+fn writeLogMessage(
+    writer: anytype,
+    comptime prefix: []const u8,
+    comptime format: []const u8,
+    args: anytype,
+    comptime error_prefix: []const u8,
+) void {
+    nosuspend {
+        writer.print(prefix ++ format ++ "\n", args) catch |e| {
+            std.debug.print("Failed to write {s}: {}\n", .{ error_prefix, e });
+            return;
+        };
+        writer.context.flush() catch |e| {
+            std.debug.print("Failed to flush {s} buffer: {}\n", .{ error_prefix, e });
+            return;
+        };
+    }
+}
+
+fn logWithPrefix(comptime actual_prefix: []const u8, comptime format: []const u8, args: anytype, comptime meta_error_ctx: []const u8) void {
+    const stderr = std.io.getStdErr().writer();
+    var bw = std.io.bufferedWriter(stderr);
+    const writer = bw.writer();
+
+    std.debug.lockStdErr();
+    defer std.debug.unlockStdErr();
+    writeLogMessage(writer, actual_prefix, format, args, meta_error_ctx);
+}


### PR DESCRIPTION
## Reporting Module Refactor

### Summary

Refactored logging into a centralized Reporting module with:

- Conditional logging controlled by verbosity flags
- Consistent error handling
- No logging by default

### Before/After Examples

**Previous usage:**

```
# anyzig 0.14.0
anyzig: appdata 'C:\Users\User\AppData\Local\anyzig'
anyzig: zig '0.14.0' already exists at 'C:\Users\User\AppData\Local\zig\p\N-V-__8AAK-dvxIG9bxtv_PhUgMjlWJBmIcxbCCqgcBJXm2T'
info: Usage: zig [command] [options]
```

**New behavior:**

```
# anyzig 0.14.0
info: Usage: zig [command] [options]
```

```
# anyzig 0.14.0 -v
anyzig: appdata 'C:\Users\User\AppData\Local\anyzig'
anyzig: zig '0.14.0' already exists at 'C:\Users\User\AppData\Local\zig\p\N-V-__8AAK-dvxIG9bxtv_PhUgMjlWJBmIcxbCCqgcBJXm2T'
info: Usage: zig [command] [options]
```

### New Flags

- `-v`, `--verbose`: Enables info-level logging
- `-d`, `--debug`: Debug logging (implemented but unused)

### Benefits

- Writer memory creation limited to two internal functions
- Simpler and more consistent error handling
- No logging by default
- Logs only display when requested or on errors

The module has a number of logging functions that can be accessed anywhere, as well as a Reporting struct which can be initiated with verbosity settings to allow for conditional logs. The logging of the other source code files has been refactored to use this module.

I have attempted to maintain the spirit of the previous logging as closely as possible. As of now all current logging was placed behind the info method which is controlled by the verbose flag. Debug is not used for now but could be useful.

## Notes

- The reporting struct instance is created in main and drilled down to functions as a reference
- The panic function is just a wrapper for Zig's standard panic function as of now
- Currently verbosity is controlled by two bools, debug and verbose. This can be expanded for more logging if needed
- Different types of logs are prefixed, anyzig.error:, anyzig.info:, ect.
- Assuming no panics or errors, default usage has NO logging without explicit use of the verbose flag
- The module is only applied to source code, not tests or anything else

## Documentation

**Global Functions (available anywhere via `Reporting.*`)**

These functions can be called directly using `Reporting.functionName(...)`.

- `Reporting.log(comptime format: []const u8, args: anytype)`
  - Prints a message to stderr without any prefix. Useful for general output like menus or formatted text.
  - Always prints, regardless of verbosity settings.
- `Reporting.throwError(comptime format: []const u8, args: anytype)`
  - Prints an error message prefixed with `anyzig.error:` to stderr.
  - Exits the program with a default exit code (`0xff`).
- `Reporting.throwErrorWithExitCode(comptime format: []const u8, args: anytype, exit_code: u8)`
  - Prints an error message prefixed with `anyzig.error:` to stderr.
  - Exits the program with the specified `exit_code`.
- `Reporting.panic(comptime format: []const u8, args: anytype)`
  - Wraps Zig's standard library `std.debug.panic`.
  - Prints a message prefixed with `anyzig.panic:` and then panics.
- `Reporting.criticalWarn(comptime format: []const u8, args: anytype)`
  - Prints a warning message prefixed with `anyzig.critical:` to stderr.
  - Always prints, regardless of verbosity settings. Used for important warnings that should always be visible.

**Conditional Logging (via `Reporter` instance)**

To use these logging functions, first create an instance of `Reporting.Reporter`. Logging behavior depends on the `verbose_enabled` and `debug_enabled` flags passed during initialization.

- `reporter.info(comptime format: []const u8, args: anytype)`
  - Prints a message prefixed with `anyzig.info:`.
  - Only prints if `verbose_enabled` was `true` during `Reporter.init()`.
- `reporter.debug(comptime format: []const u8, args: anytype)`
  - Prints a message prefixed with `anyzig.debug:`.
  - Only prints if `debug_enabled` was `true` during `Reporter.init()`.
- `reporter.warn(comptime format: []const u8, args: anytype)`
  - Prints a message prefixed with `anyzig.warn:`.
  - Prints if either `verbose_enabled` or `debug_enabled` was `true` during `Reporter.init()`.

**Internal Writer Methods (for module use only)**

These functions are not intended for direct use outside of `reporting.zig`.

- `writeLogMessage(...)`
- `logWithPrefix(...)`

## Example Usage

```
const Reporting = import("reporting.zig");

fn notNeeded() {
    Reporting.log("I can be accessed anywhere and always print", .{});
}

fn needed(report: Reporting.Reporter) {
    report.info("I can be accessed via Reporter instance and only print when requested", .{});
}

fn main() {
    const report = Reporting.Reporter.init(verbose_enabled, debug_enabled);
    notNeeded();
    needed(report);
}
```
