### PR TITLE
fix 404 not found from OS-ARCH url swap to ARCH-OS in 0.14.1 and dev versions

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
-      - uses: mlugg/setup-zig@v1
+      - uses: mlugg/setup-zig@v2
       - run: |
           zig build ci --summary all
       - if: ${{ matrix.os == 'ubuntu-latest' && matrix.arch == 'x86_64' }}

--- a/build.zig
+++ b/build.zig
@@ -399,6 +399,7 @@ const ZigRelease = enum {
     @"0.12.1",
     @"0.13.0",
     @"0.14.0",
+    @"0.14.1",
     @"2024.11.0-mach",
 
     pub fn getInitKind(self: ZigRelease) enum { simple, exe_and_lib } {


### PR DESCRIPTION
For any release at or newer than `0.14.1`, anyzig now uses the new `ARCH-OS` ordering to generate the official URL.  It also uses the new ordering for dev urls as the only ones still available seem to be ones that use the new ordering.

Not sure what mach does for the ordering, but, for mach we should already be using their download index for the URLs so we might be fine?