### PR TITLE
Add `s390x-linux` support.

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -27,6 +27,8 @@ jobs:
           - os: ubuntu-latest
             arch: riscv64
           - os: ubuntu-latest
+            arch: s390x
+          - os: ubuntu-latest
             arch: x86
           - os: ubuntu-latest
             arch: x86_64
@@ -52,6 +54,7 @@ jobs:
             zig-out/anyzig-arm-linux.tar.gz
             zig-out/anyzig-powerpc64le-linux.tar.gz
             zig-out/anyzig-riscv64-linux.tar.gz
+            zig-out/anyzig-s390x-linux.tar.gz
             zig-out/anyzig-x86-linux.tar.gz
             zig-out/anyzig-x86-windows.zip
             zig-out/anyzig-x86_64-linux.tar.gz

--- a/build.zig
+++ b/build.zig
@@ -533,6 +533,7 @@ fn ci(
         "arm-linux",
         "powerpc64le-linux",
         "riscv64-linux",
+        "s390x-linux",
         "x86-linux",
         "x86-windows",
         "x86_64-linux",

--- a/src/main.zig
+++ b/src/main.zig
@@ -662,6 +662,7 @@ const arch = switch (builtin.cpu.arch) {
     .arm => "armv7a",
     .powerpc64le => "powerpc64le",
     .riscv64 => "riscv64",
+    .s390x => "s390x",
     .x86 => "x86",
     .x86_64 => "x86_64",
     else => @compileError("Unsupported CPU Architecture"),


### PR DESCRIPTION
This appeared in Zig 0.14.1.