### PR TITLE
Added feature to show installed versions

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -38,6 +38,30 @@ const Verbosity = enum {
     pub const default: Verbosity = .debug;
 };
 
+/// Represents an installed Zig version with its version string and installation path
+const ZigInstall = struct {
+    version: []const u8,
+    path: []const u8,
+};
+
+/// Context for scanning and processing Zig installations in the global cache
+const HashstoreContext = struct {
+    // right now we only search the p directory in the global zig cache
+    // from my experience this is where zig installs are stored
+    // the search should start higher and be deeper if more flexibility is needed
+    p_dir: std.fs.Dir,
+    hashstore_dir: std.fs.Dir,
+    hashstore_path: []const u8,
+    p_dir_path: []const u8,
+
+    fn deinit(self: *HashstoreContext) void {
+        self.hashstore_dir.close();
+        self.p_dir.close();
+        global.arena.free(self.hashstore_path);
+        global.arena.free(self.p_dir_path);
+    }
+};
+
 const global = struct {
     var gpa_instance: std.heap.GeneralPurposeAllocator(.{}) = .{};
     const gpa = gpa_instance.allocator();
@@ -283,6 +307,12 @@ fn determineSemanticVersion(scratch: Allocator, build_root: BuildRoot) !Semantic
 }
 
 pub fn main() !void {
+    // this is a workaround for windows not supporting utf-8 by default
+    // it currently allows us to print trees with unicode characters
+    if (builtin.os.tag == .windows) {
+        _ = std.os.windows.kernel32.SetConsoleOutputCP(65001); // UTF-8
+    }
+
     defer _ = global.gpa_instance.deinit();
     const gpa = global.gpa;
 
@@ -579,54 +609,214 @@ fn anyCommand(command: []const u8, args: []const []const u8) !u8 {
     } else errExit("unknown zig any '{s}' command", .{command});
 }
 
+//this is the entry point for displaying releases
 fn showInstalledReleases() !void {
+    // start by verifying all installed versions are in the hashstore
+    const installs = try updateHashstore();
+    defer {
+        for (installs) |install| {
+            global.arena.free(install.version);
+            global.arena.free(install.path);
+        }
+        global.arena.free(installs);
+    }
+
+    const stdout = io.getStdOut().writer();
+    try stdout.print("Installed Zig releases\n", .{});
+    try stdout.print("----------------------\n", .{});
+
+    const master_version_name = try std.fmt.allocPrint(global.arena, "{s}-master", .{exe_str});
+    defer global.arena.free(master_version_name);
+
     const app_data_path = try std.fs.getAppDataDir(global.arena, "anyzig");
     defer global.arena.free(app_data_path);
 
     const hashstore_path = try std.fs.path.join(global.arena, &.{ app_data_path, "hashstore" });
-    try hashstore.init(hashstore_path);
     defer global.arena.free(hashstore_path);
 
-    const stdout = io.getStdOut().writer();
-    try stdout.print("Installed Zig releases for {s}-{s}:\n", .{ os, arch });
-
-    const master_version_name = std.fmt.allocPrint(global.arena, "{s}-master", .{exe_str}) catch |e| oom(e);
-    defer global.arena.free(master_version_name);
-
     const is_master_installed = hashstore.find(hashstore_path, master_version_name) catch |err| {
+        // this warns but continues rather than erroring out
         log.warn("Failed to check if master is installed: {s}", .{@errorName(err)});
         return;
     } != null;
 
     if (is_master_installed) {
-        try stdout.print("master (installed)\n", .{});
+        try stdout.print("Master ", .{});
+        if (try hashstore.find(hashstore_path, master_version_name)) |master_hash| {
+            const exe = try resolveZigExePath(global.arena, master_hash.toSlice());
+            defer global.arena.free(exe);
+            try callZigVersion(exe);
+        }
     }
 
-    var dir = std.fs.cwd().openDir(hashstore_path, .{ .iterate = true }) catch |err| {
-        errExit("Failed to open hashstore directory: {s}", .{@errorName(err)});
-    };
-    defer dir.close();
-
-    var walker = try dir.walk(global.arena);
-    defer walker.deinit();
-
     var found_any = false;
-    while (try walker.next()) |entry| {
-        if (entry.kind == .file) {
-            const file_name = entry.basename;
-            if (std.mem.startsWith(u8, file_name, exe_str)) {
-                const version_part = file_name[exe_str.len + 1 ..]; // +1 for the '-'
-                if (!std.mem.eql(u8, version_part, "master")) {
-                    try stdout.print("{s}\n", .{version_part});
-                    found_any = true;
-                }
-            }
+    for (installs) |install| {
+        if (!std.mem.eql(u8, install.version, "master")) {
+            try stdout.print("{s}\n", .{install.version});
+            const exe = try resolveZigExePath(global.arena, install.path);
+            defer global.arena.free(exe);
+            try callZigVersion(exe);
+            found_any = true;
         }
     }
 
     if (!found_any and !is_master_installed) {
         log.warn("No installed versions found for {s}-{s}", .{ os, arch });
     }
+}
+
+// Resolves the full path to the Zig executable for a given hash path
+// used to create an exe path for the callZigVersion function
+fn resolveZigExePath(arena: Allocator, hash_path: []const u8) ![]const u8 {
+    const override_global_cache_dir: ?[]const u8 = try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(arena);
+    const global_cache_path = override_global_cache_dir orelse try introspect.resolveGlobalCacheDir(arena);
+    defer if (override_global_cache_dir) |p| arena.free(p);
+    defer arena.free(global_cache_path);
+
+    const p_dir_path = try std.fs.path.join(arena, &.{ global_cache_path, "p" });
+    defer arena.free(p_dir_path);
+
+    const install_path = try std.fs.path.join(arena, &.{ p_dir_path, hash_path });
+    defer arena.free(install_path);
+
+    const exe_name = if (builtin.os.tag == .windows) "zig.exe" else "zig";
+    return try std.fs.path.join(arena, &.{ install_path, exe_name });
+}
+
+// Executes 'zig version' for a given executable and displays the output
+// prints the version info for the zig install directly
+// uses a "--" prefix to separate the output from name of the install
+fn callZigVersion(exe: []const u8) !void {
+    var child = std.process.Child.init(&.{ exe, "version" }, global.arena);
+    child.stdout_behavior = .Pipe;
+    try child.spawn();
+
+    const stdout = try child.stdout.?.reader().readAllAlloc(global.arena, std.math.maxInt(usize));
+    defer global.arena.free(stdout);
+
+    const result = try child.wait();
+    if (result == .Exited and result.Exited == 0) {
+        try std.io.getStdOut().writer().print("└ version: {s}", .{stdout});
+    } else {
+        log.err("Failed to get version information from Zig executable '{s}': {s}", .{ exe, "Failure to call zig version" });
+        return error.VersionCheckFailed;
+    }
+}
+
+// Initializes the context for scanning Zig installations in the global cache
+fn initHashstoreContext() !HashstoreContext {
+    const app_data_path = try std.fs.getAppDataDir(global.arena, "anyzig");
+    const hashstore_path = try std.fs.path.join(global.arena, &.{ app_data_path, "hashstore" });
+    try hashstore.init(hashstore_path);
+
+    const override_global_cache_dir: ?[]const u8 = try EnvVar.ZIG_GLOBAL_CACHE_DIR.get(global.arena);
+    const global_cache_path = override_global_cache_dir orelse try introspect.resolveGlobalCacheDir(global.arena);
+    if (override_global_cache_dir) |p| global.arena.free(p);
+
+    const p_dir_path = try std.fs.path.join(global.arena, &.{ global_cache_path, "p" });
+
+    log.info("Scanning global cache at '{s}'", .{global_cache_path});
+
+    const p_dir = std.fs.cwd().openDir(p_dir_path, .{ .iterate = true }) catch |err| {
+        log.warn("No 'p' directory in global cache: {s}", .{@errorName(err)});
+        return error.NoPDirectory;
+    };
+
+    const hashstore_dir = try std.fs.cwd().openDir(hashstore_path, .{ .iterate = true });
+
+    return HashstoreContext{
+        .p_dir = p_dir,
+        .hashstore_dir = hashstore_dir,
+        .hashstore_path = hashstore_path,
+        .p_dir_path = p_dir_path,
+    };
+}
+
+// Processes a single directory entry to check if it's a Zig installation and updates the installs list
+fn processDirectoryEntry(ctx: *HashstoreContext, dir_name: []const u8, installs: *std.ArrayList(ZigInstall)) !void {
+    const full_path = try std.fs.path.join(global.arena, &.{ ctx.p_dir_path, dir_name });
+    defer global.arena.free(full_path);
+
+    if (!try isZigInstall(full_path)) {
+        log.debug("Not a Zig install: {s}", .{dir_name});
+        return;
+    }
+
+    var found_match = false;
+    var hashstore_it = ctx.hashstore_dir.iterate();
+    while (try hashstore_it.next()) |hash_entry| {
+        if (hash_entry.kind == .file) {
+            if (try hashstore.find(ctx.hashstore_path, hash_entry.name)) |stored_hash| {
+                if (std.mem.eql(u8, stored_hash.toSlice(), dir_name)) {
+                    log.debug("Directory name {s} matches hashstore hash in {s}", .{ dir_name, hash_entry.name });
+                    try installs.append(.{
+                        .version = try global.arena.dupe(u8, hash_entry.name[exe_str.len + 1 ..]),
+                        .path = try global.arena.dupe(u8, dir_name),
+                    });
+                    found_match = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!found_match) {
+        // uses a prefix to avoid conflicts with anyzig-managed installs
+        const hashstore_name = try std.fmt.allocPrint(global.arena, "{s}-ext-{s}", .{ exe_str, dir_name });
+        log.debug("Not in hashstore, adding: {s} -> {s}", .{ hashstore_name, dir_name });
+        try hashstore.save(ctx.hashstore_path, hashstore_name, dir_name);
+        try installs.append(.{
+            .version = try global.arena.dupe(u8, dir_name),
+            .path = try global.arena.dupe(u8, dir_name),
+        });
+    }
+}
+
+// Updates the hashstore with current Zig installations
+// returns a list of all installations found
+// this will also add installs external to anyzig
+// it skips anything it can find in the hashstore already
+// it uses directory names as an entry for unhashed/external installs
+// unhashed/external installs have that directory name as an entry
+fn updateHashstore() ![]ZigInstall {
+    var ctx = try initHashstoreContext();
+    defer ctx.deinit();
+
+    var installs = std.ArrayList(ZigInstall).init(global.arena);
+    // ownership is transferred to the slice so we only need errdefer here
+    errdefer {
+        for (installs.items) |install| {
+            global.arena.free(install.version);
+            global.arena.free(install.path);
+        }
+        installs.deinit();
+    }
+
+    var it = ctx.p_dir.iterate();
+    while (try it.next()) |entry| {
+        if (entry.kind != .directory) continue;
+        try processDirectoryEntry(&ctx, entry.name, &installs);
+    }
+
+    return installs.toOwnedSlice();
+}
+
+// Checks if a directory contains a lib directory and zig executable
+// current zig releases have a lib and a docs directory however certain older
+// zig versions do not have a doc directory so it is ignored here intentionally
+// if verification needs to be increased, use the licence file
+fn isZigInstall(dir_path: []const u8) !bool {
+    var dir = try std.fs.cwd().openDir(dir_path, .{});
+    defer dir.close();
+
+    // Check for lib directory and zig executable
+    const zig_exe = if (builtin.target.os.tag == .windows) "zig.exe" else "zig";
+
+    // Try to access both files, return false if either doesn't exist
+    dir.access("lib", .{}) catch return false;
+    dir.access(zig_exe, .{}) catch return false;
+
+    return true;
 }
 
 const SemanticVersion = struct {


### PR DESCRIPTION
# Show Installed Releases

## Description
Added a command to show currently installed Zig versions in cache

## Changes
- Added `showInstalledReleases` function to display installed versions
- Usage falls under the any subcommand: `any list-installed`
- Now using a generalized updateHashstore function that can be reused in later features (cleanup, removal, etc.)

## Testing
- Functional on Windows and Arch (both x86)

## Notes
- Robust implementation of checking installs
- Installs are confirmed by calling `zig version` on the underlying executable
- Crawls the p dir in Zig cache to find installations (this can be expanded to make more flexible if needed)
- Installations found which were not added by anyzig are given an `ext-` prefix to prevent overlaps in naming
- The feature shows current master version as well
- Forced windows to use UTF-8 so we can print more consistently (feature uses "└" char)

## Example output
```
Installed Zig releases
----------------------
ext-zig-install-named-whatever
└ version: 0.12.1
ext-0.14.0
└ version: 0.14.0
0.14.0
└ version: 0.14.0
2024.11.0-mach
└ version: 0.14.0-dev.2577+271452d22
```

## Function Documentation

## `showInstalledReleases()`
The main entry point for displaying installed Zig releases.
This is the only function which needs to be called, the rest are internal and helper functions
- Verifies all installed versions are in the hashstore
- Displays a formatted list of all installed versions
- Handles both regular versions and master version
- Shows version information for each installation via `zig version`

## `resolveZigExePath(arena: Allocator, hash_path: []const u8)`
Resolves the full path to the Zig executable for a given hash path.
- Parameters:
  - `arena`: Memory allocator for path construction
  - `hash_path`: The hash path of the Zig installation
- Returns: Full path to the zig executable
- Handles platform-specific executable names (zig.exe on Windows)

## `callZigVersion(exe: []const u8)`
Executes 'zig version' for a given executable and displays the output.
- Parameters:
  - `exe`: Path to the Zig executable
- Prints version info with a "└" prefix to separate from installation name
- Handles execution errors gracefully

## `initHashstoreContext()`
Initializes the context for scanning Zig installations in the global cache.
- Returns: `HashstoreContext` containing:
  - `p_dir`: Directory handle for the global cache 'p' directory
  - `hashstore_dir`: Directory handle for the hashstore
  - `hashstore_path`: Path to the hashstore
  - `p_dir_path`: Path to the global cache 'p' directory

## `processDirectoryEntry(ctx: *HashstoreContext, dir_name: []const u8, installs: *std.ArrayList(ZigInstall))`
Processes a single directory entry to check if it's a Zig installation.
- Parameters:
  - `ctx`: Hashstore context
  - `dir_name`: Name of the directory to process
  - `installs`: List to append valid installations to
- Updates the installs list with found Zig installations
- Handles both anyzig-managed and external installations

## `updateHashstore()`
Updates the hashstore with current Zig installations.
This could come in handy for other features down the line
- Returns: List of all installations found
- Adds external installs not managed by anyzig
- Skips installations already in the hashstore
- Uses directory names as entries for unhashed/external installs

## `isZigInstall(dir_path: []const u8)`
Checks if a directory contains a valid Zig installation.
- Parameters:
  - `dir_path`: Path to the directory to check
- Returns: Boolean indicating if the directory is a valid Zig installation
- Verifies presence of:
  - lib directory
  - zig executable (platform-specific)