### PR TITLE
support ".zig_version" in build.zig.zon

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -413,6 +413,25 @@ fn addTests(
         const write_files = b.addWriteFiles();
         _ = write_files.add("build.zig", "");
         _ = write_files.add("build.zig.zon",
+            \\.{
+            \\    .minimum_zig_version = "0.13.0",
+            \\    .zig_version = "0.14.0",
+            \\}
+            \\
+        );
+        const t = test_factory.add(.{
+            .name = "test-zig-version",
+            .input_dir = .{ .path = write_files.getDirectory() },
+            .options = .nosetup,
+            .args = &.{"version"},
+        });
+        t.run.expectStdOutEqual("0.14.0\n");
+    }
+
+    {
+        const write_files = b.addWriteFiles();
+        _ = write_files.add("build.zig", "");
+        _ = write_files.add("build.zig.zon",
             \\// example comment
             \\.{
             \\    .minimum_zig_version = "0.13.0",


### PR DESCRIPTION
I've created a [proposal](https://github.com/ziglang/zig/issues/23985) to officially support and require .zig_version in build.zig.zon.  However, I'd like to start using this now.  This should be ok for now as zig currently allows unknown fields in the zon file.