### PR TITLE
Bugfix: ZLS download using incorrect target

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -875,16 +875,73 @@ fn makeOfficialUrl(arena: Allocator, semantic_version: SemanticVersion) Download
     };
 }
 
+fn findZlsTarball(arena: Allocator, zig_version: SemanticVersion) ![]const u8 {
+    var client = std.http.Client{ .allocator = arena };
+    defer client.deinit();
+    try client.initDefaultProxies(arena);
+
+    const api_url = std.fmt.allocPrint(
+        arena,
+        "https://releases.zigtools.org/v1/zls/select-version?zig_version={}&compatibility=only-runtime",
+        .{zig_version},
+    ) catch |e| oom(e);
+    defer arena.free(api_url);
+
+    var header_buffer: [4096]u8 = undefined;
+    var request = client.open(.GET, std.Uri.parse(api_url) catch |err| return err, .{
+        .server_header_buffer = &header_buffer,
+    }) catch |err| return err;
+    defer request.deinit();
+
+    try request.send();
+    try request.wait();
+
+    const status = request.response.status;
+
+    const body = try request.reader().readAllAlloc(arena, std.math.maxInt(usize));
+    defer arena.free(body);
+
+    if (status.class() != .success) {
+        return errExit("zls: HTTP {} from zigtools: {s}", .{ @intFromEnum(status), body });
+    }
+
+    var parsed = std.json.parseFromSlice(std.json.Value, arena, body, .{ .allocate = .alloc_if_needed }) catch |e| std.debug.panic(
+        "failed to parse zigtools releases response as JSON with {s}",
+        .{@errorName(e)},
+    );
+    defer parsed.deinit();
+
+    const obj = parsed.value.object;
+    if (obj.get("message")) |msg| {
+        return errExit("zls: {s}", .{msg.string});
+    }
+
+    // Prefer ARCH-OS key, fallback to OS-ARCH
+    const tarball = blk: {
+        if (obj.get(arch_os)) |entry| {
+            if (entry.object.get("tarball")) |t| break :blk t.string;
+        }
+        if (obj.get(os_arch)) |entry| {
+            if (entry.object.get("tarball")) |t| break :blk t.string;
+        }
+        return errExit(
+            "zls build not found for {} (no artifact for '{s}' or '{s}')",
+            .{ zig_version, arch_os, os_arch },
+        );
+    };
+
+    log.debug("zls tarball '{s}'", .{tarball});
+
+    return try arena.dupe(u8, tarball);
+}
+
 fn getVersionUrl(
     arena: Allocator,
     app_data_path: []const u8,
     semantic_version: SemanticVersion,
 ) !DownloadUrl {
-    if (build_options.exe == .zls) return DownloadUrl.initOfficial(std.fmt.allocPrint(
-        arena,
-        "https://builds.zigtools.org/zls-{s}-{}.{s}",
-        .{ os_arch, semantic_version, archive_ext },
-    ) catch |e| oom(e));
+    if (build_options.exe == .zls)
+        return DownloadUrl.initOfficial(try findZlsTarball(arena, semantic_version));
 
     if (!isMachVersion(semantic_version)) return makeOfficialUrl(arena, semantic_version);
 


### PR DESCRIPTION
Fixes: https://github.com/marler8997/anyzig/issues/67

Bug:

In certain conditions Anyzig would target the wrong link when trying to download the Zig Language Server. 

Problem:

There were two conditions found that would cause this error:  
1) Using a version of Zig which doesn't map to a ZLS release. Because ZLS doesn't keep the same versioning as Zig, using the compiler version directly can fail.  
FIX: Zigtools offers a tool to match Zig version to ZLS version.  

2) Zigtools has swapped the placement of OS and ARCH on the name of their latest binary release. This means the current target parsing is broken on the latest ZLS version.  
FIX: Prefer ARCH-OS key, fallback to OS-ARCH.


Changes:

Created a function to call the ZLS version matching tool and do the fallback logic if the OS/ARCH are suspected to be swapped. The only change to existing code is calling this function rather than trying the download directly.

Previous behavior:  
```
anyzig: zig version '0.15.1' pulled from 'C:\dev\zig\doxa\build.zig.zon'
anyzig: appdata 'C:\Users\User\AppData\Local\anyzig'
anyzig: downloading 'https://builds.zigtools.org/zls-windows-x86_64-0.15.1.zip'...
error: bad HTTP response code: '404 Not Found'
```

New behavior:  
```
anyzig: zig version '0.15.1' pulled from 'C:\dev\zig\doxa\build.zig.zon'       
anyzig: appdata 'C:\Users\User\AppData\Local\anyzig'
anyzig: debug: zls tarball 'https://builds.zigtools.org/zls-x86_64-windows-0.15.0.zip'
anyzig: downloading 'https://builds.zigtools.org/zls-x86_64-windows-0.15.0.zip'...
anyzig: downloaded zls-0.15.1 to 'C:\Users\User\AppData\Local\zig\p\N-V-__8AAKcO5QDO6ePs_xjItIpKxJA3ITHFlY-JbPNLpTAB'
ZLS - A non-official language server for Zig

Commands:
  help, --help,             Print this help and exit
  version, --version        Print version number and exit
  env                       Print config path, log path and version

General Options:
  --config-path [path]      Set path to the 'zls.json' configuration file      
  --log-file [path]         Set path to the 'zls.log' log file
  --log-level [enum]        The Log Level to be used.
                              Supported Values:
                                err
                                warn
                                info (default)
                                debug

Advanced Options:
  --enable-stderr-logs      Write log message to stderr
  --disable-lsp-logs        Disable LSP 'window/logMessage' messages
```