### PR TITLE
update nominated zig index.json location

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -808,7 +808,7 @@ const DownloadIndexKind = enum {
     pub fn url(self: DownloadIndexKind) []const u8 {
         return switch (self) {
             .official => "https://ziglang.org/download/index.json",
-            .mach => "https://machengine.org/zig/index.json",
+            .mach => "https://pkg.hexops.org/zig/index.json",
         };
     }
     pub fn uri(self: DownloadIndexKind) std.Uri {


### PR DESCRIPTION
Mach has a new home to fetch the index.json for its nominated Zig versions: https://pkg.hexops.org/zig/index.json

The old URL will continue to exist/function just fine, but this is the authoritative location now.

(pkg.machengine.org also now redirects to https://pkg.hexops.org which is running a Zig mirror implementation, https://code.hexops.org/hexops/pkgmirror, instead of our old golang based wrench mirror service)