### PR TITLE
fix: resolve underlying Zig version for Mach builds in anyzls

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -240,10 +240,68 @@ fn isMachVersion(v: SemanticVersion) bool {
     return false;
 }
 
-fn stripMachVersion(v: SemanticVersion) SemanticVersion {
-    var result = v;
-    result.pre = null;
-    return result;
+fn extractZigVersionFromMachIndex(
+    arena: Allocator,
+    app_data_path: []const u8,
+    semantic_version: SemanticVersion,
+) !SemanticVersion {
+    const download_index_kind: DownloadIndexKind = .mach;
+    const index_path = try std.fs.path.join(arena, &.{ app_data_path, download_index_kind.basename() });
+    defer arena.free(index_path);
+
+    // Try existing cached index first.
+    try_existing_index: {
+        const index_content = blk: {
+            const file = std.fs.cwd().openFile(index_path, .{}) catch |err| switch (err) {
+                error.FileNotFound => break :try_existing_index,
+                else => |e| return e,
+            };
+            defer file.close();
+            break :blk try file.readToEndAlloc(arena, std.math.maxInt(usize));
+        };
+        defer arena.free(index_content);
+        if (extractVersionFromMachIndex(arena, semantic_version, index_path, index_content)) |v|
+            return v;
+    }
+
+    // Cache miss or version not found -- fetch fresh index.
+    try fetchFile(arena, download_index_kind.url(), download_index_kind.uri(), index_path);
+    const index_content = blk: {
+        const file = try std.fs.cwd().openFile(index_path, .{});
+        defer file.close();
+        break :blk try file.readToEndAlloc(arena, std.math.maxInt(usize));
+    };
+    defer arena.free(index_content);
+    return extractVersionFromMachIndex(arena, semantic_version, index_path, index_content) orelse {
+        errExit("compiler version '{}' is missing from mach download index {s}", .{ semantic_version, index_path });
+    };
+}
+
+fn extractVersionFromMachIndex(
+    scratch: Allocator,
+    semantic_version: SemanticVersion,
+    index_filepath: []const u8,
+    download_index: []const u8,
+) ?SemanticVersion {
+    const root = std.json.parseFromSlice(std.json.Value, scratch, download_index, .{
+        .allocate = .alloc_if_needed,
+    }) catch |e| std.debug.panic(
+        "failed to parse download index '{s}' as JSON with {s}",
+        .{ index_filepath, @errorName(e) },
+    );
+    defer root.deinit();
+
+    const version_array = semantic_version.array();
+    const version_str = version_array.slice();
+    const version_obj = root.value.object.get(version_str) orelse return null;
+    const zig_version_val = version_obj.object.get("version") orelse std.debug.panic(
+        "mach download index '{s}' version '{s}' is missing the 'version' property",
+        .{ index_filepath, version_str },
+    );
+    return SemanticVersion.parse(zig_version_val.string) orelse errExit(
+        "unable to parse zig version '{s}' from mach download index",
+        .{zig_version_val.string},
+    );
 }
 
 fn determineSemanticVersion(scratch: Allocator, build_root: BuildRoot) !SemanticVersion {
@@ -885,9 +943,10 @@ fn getVersionUrl(
     semantic_version: SemanticVersion,
 ) !DownloadUrl {
     if (build_options.exe == .zls) {
-        // ZLS doesn't have Mach versions, so strip the -mach suffix
+        // ZLS doesn't have Mach versions. Look up the underlying Zig version
+        // from the Mach download index and use that for the ZLS URL.
         const zls_version = if (isMachVersion(semantic_version))
-            stripMachVersion(semantic_version)
+            try extractZigVersionFromMachIndex(arena, app_data_path, semantic_version)
         else
             semantic_version;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -240,6 +240,12 @@ fn isMachVersion(v: SemanticVersion) bool {
     return false;
 }
 
+fn stripMachVersion(v: SemanticVersion) SemanticVersion {
+    var result = v;
+    result.pre = null;
+    return result;
+}
+
 fn determineSemanticVersion(scratch: Allocator, build_root: BuildRoot) !SemanticVersion {
     const zon = try loadBuildZigZon(scratch, build_root) orelse {
         log.err("TODO: no build.zig.zon file, maybe try determining zig version from build.zig?", .{});
@@ -878,17 +884,25 @@ fn getVersionUrl(
     app_data_path: []const u8,
     semantic_version: SemanticVersion,
 ) !DownloadUrl {
-    if (build_options.exe == .zls) return DownloadUrl.initOfficial(std.fmt.allocPrint(
-        arena,
-        "https://builds.zigtools.org/zls-{s}-{}.{s}",
-        .{ switch (determineVersionKind(semantic_version)) {
-            .dev => arch_os,
-            .release => |release| switch (release.order(arch_os_swap_release)) {
-                .lt => os_arch,
-                .gt, .eq => arch_os,
-            },
-        }, semantic_version, archive_ext },
-    ) catch |e| oom(e));
+    if (build_options.exe == .zls) {
+        // ZLS doesn't have Mach versions, so strip the -mach suffix
+        const zls_version = if (isMachVersion(semantic_version))
+            stripMachVersion(semantic_version)
+        else
+            semantic_version;
+
+        return DownloadUrl.initOfficial(std.fmt.allocPrint(
+            arena,
+            "https://builds.zigtools.org/zls-{s}-{}.{s}",
+            .{ switch (determineVersionKind(zls_version)) {
+                .dev => arch_os,
+                .release => |release| switch (release.order(arch_os_swap_release)) {
+                    .lt => os_arch,
+                    .gt, .eq => arch_os,
+                },
+            }, zls_version, archive_ext },
+        ) catch |e| oom(e));
+    }
 
     if (!isMachVersion(semantic_version)) return makeOfficialUrl(arena, semantic_version);
 


### PR DESCRIPTION
## Summary
- Fix crash when anyzls encounters Mach Zig version strings by resolving the underlying Zig version from the index metadata
- Mach versions (e.g., `0.14.0-dev.3163+0`) are not valid semver for ZLS compatibility checks; the fix maps them to their base Zig release version

Fixes #73

## Test plan
- anyzls no longer crashes when encountering Mach version strings
- Standard semver versions continue to work unchanged